### PR TITLE
Add Gantt Chart Documentation to Main Branch

### DIFF
--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -15,6 +15,6 @@ gantt
     section Phase 3B
     Setup & Implementation Iteration 2        :p3b, 2025-11-24, 2025-12-07
     section Phase 4A
-    Testing & Validation                      :p4a, 2025-11-24, 2025-12-14
+    Testing & Validation                      :p4a, 2025-12-08, 2025-12-14
     section Phase 4B
     Final Submission                          :milestone, p4b, 2025-12-14, 2025-12-20


### PR DESCRIPTION
This PR adds Gantt Chart documentation updates intended for the `main` branch as per project guidelines. These changes are documentation-only and do not affect development code, so they should reside in `main`.

Previous PR was closed because it was assumed to target `dev`. However, documentation updates are meant for `main`. Please review and confirm.