### PR TITLE
[Phase 3A]: Add canonical test-data, run-results, schemas and seeding scripts (feature/test-data)

### DIFF
--- a/runner/test-data/README.md
+++ b/runner/test-data/README.md
@@ -1,0 +1,19 @@
+# Test Data for TestCraft
+
+This folder provides canonical and example test specifications and run-results for local development, QA, and CI.
+
+## Structure
+- `generated-tests/canonical` — authoritative test specs used across teams.
+- `generated-tests/ci-regression` — manifests / suites for CI.
+- `generated-tests/examples` — simple examples for demos.
+- `run-results/canonical` — canonical run outputs to simulate the runner.
+- `run-results/examples` — simple demo run outputs.
+- `manifests` — JSON schemas for recorder and generated Playwright specs.
+- `scripts` — helper scripts to seed and bundle data.
+
+## Quick seed (demo)
+From project root:
+
+```bash
+node runner/test-data/scripts/seed-sample-data.js --target demo
+```

--- a/runner/test-data/generated-tests/canonical/checkout_flow.json
+++ b/runner/test-data/generated-tests/canonical/checkout_flow.json
@@ -1,0 +1,17 @@
+{
+  "id": "AC-CHECKOUT-001",
+  "name": "Checkout Flow - Add to Cart and Complete Purchase",
+  "description": "End-to-end checkout flow from product selection to order confirmation",
+  "project_id": 2,
+  "tags": ["e2e","checkout"],
+  "priority": "P1",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/products" },
+    { "order": 2, "action": "click", "selector": ".product-item:first-child .add-to-cart" },
+    { "order": 3, "action": "click", "selector": ".cart .checkout" },
+    { "order": 4, "action": "input", "selector": "#address", "value": "221B Baker Street" },
+    { "order": 5, "action": "input", "selector": "#card", "value": "4111111111111111" },
+    { "order": 6, "action": "click", "selector": "button.complete-order" },
+    { "order": 7, "action": "assert", "selector": ".order-confirmation", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/canonical/login_invalid_password.json
+++ b/runner/test-data/generated-tests/canonical/login_invalid_password.json
@@ -1,0 +1,15 @@
+{
+  "id": "AC-LOGIN-002",
+  "name": "Login - Invalid Password",
+  "description": "Login with wrong password should display an error message",
+  "project_id": 1,
+  "tags": ["regression","auth"],
+  "priority": "P2",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/login" },
+    { "order": 2, "action": "input", "selector": "#email", "value": "user@example.com" },
+    { "order": 3, "action": "input", "selector": "#password", "value": "wrong_password" },
+    { "order": 4, "action": "click", "selector": "button[type='submit']" },
+    { "order": 5, "action": "assert", "selector": ".error-message", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/canonical/login_valid.json
+++ b/runner/test-data/generated-tests/canonical/login_valid.json
@@ -1,0 +1,15 @@
+{
+  "id": "AC-LOGIN-001",
+  "name": "Login - Valid Credentials",
+  "description": "Valid login should succeed and redirect to dashboard",
+  "project_id": 1,
+  "tags": ["smoke","auth"],
+  "priority": "P1",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/login" },
+    { "order": 2, "action": "input", "selector": "#email", "value": "user@example.com" },
+    { "order": 3, "action": "input", "selector": "#password", "value": "correct_password" },
+    { "order": 4, "action": "click", "selector": "button[type='submit']" },
+    { "order": 5, "action": "assert", "selector": ".dashboard-welcome", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/checkout_flow.json
+++ b/runner/test-data/generated-tests/checkout_flow.json
@@ -1,0 +1,17 @@
+{
+  "id": "AC-CHECKOUT-001",
+  "name": "Checkout Flow - Add to Cart and Complete Purchase",
+  "description": "End-to-end checkout flow from product selection to order confirmation",
+  "project_id": 2,
+  "tags": ["e2e","checkout"],
+  "priority": "P1",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/products" },
+    { "order": 2, "action": "click", "selector": ".product-item:first-child .add-to-cart" },
+    { "order": 3, "action": "click", "selector": ".cart .checkout" },
+    { "order": 4, "action": "input", "selector": "#address", "value": "221B Baker Street" },
+    { "order": 5, "action": "input", "selector": "#card", "value": "4111111111111111" },
+    { "order": 6, "action": "click", "selector": "button.complete-order" },
+    { "order": 7, "action": "assert", "selector": ".order-confirmation", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/ci-regression/regression-bundle.json
+++ b/runner/test-data/generated-tests/ci-regression/regression-bundle.json
@@ -1,0 +1,8 @@
+{
+  "generated_at": "2025-11-19T20:00:26.501Z",
+  "tests": [
+    "..\\canonical\\checkout_flow.json",
+    "..\\canonical\\login_invalid_password.json",
+    "..\\canonical\\login_valid.json"
+  ]
+}

--- a/runner/test-data/generated-tests/ci-regression/regression-suite-1.json
+++ b/runner/test-data/generated-tests/ci-regression/regression-suite-1.json
@@ -1,0 +1,10 @@
+{
+  "suite_id": "regression-001",
+  "name": "Nightly Regression Suite #1",
+  "description": "Core smoke and regression tests to run nightly",
+  "tests": [
+    "../canonical/login_valid.json",
+    "../canonical/login_invalid_password.json",
+    "../canonical/checkout_flow.json"
+  ]
+}

--- a/runner/test-data/generated-tests/examples/sample-test-1.json
+++ b/runner/test-data/generated-tests/examples/sample-test-1.json
@@ -1,0 +1,9 @@
+{
+  "id": "SAMPLE-001",
+  "name": "Sample Test - Simple navigation",
+  "project_id": 1,
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com" },
+    { "order": 2, "action": "assert", "selector": "body", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/login_invalid_password.json
+++ b/runner/test-data/generated-tests/login_invalid_password.json
@@ -1,0 +1,15 @@
+{
+  "id": "AC-LOGIN-002",
+  "name": "Login - Invalid Password",
+  "description": "Login with wrong password should display an error message",
+  "project_id": 1,
+  "tags": ["regression","auth"],
+  "priority": "P2",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/login" },
+    { "order": 2, "action": "input", "selector": "#email", "value": "user@example.com" },
+    { "order": 3, "action": "input", "selector": "#password", "value": "wrong_password" },
+    { "order": 4, "action": "click", "selector": "button[type='submit']" },
+    { "order": 5, "action": "assert", "selector": ".error-message", "value": "visible" }
+  ]
+}

--- a/runner/test-data/generated-tests/login_valid.json
+++ b/runner/test-data/generated-tests/login_valid.json
@@ -1,0 +1,15 @@
+{
+  "id": "AC-LOGIN-001",
+  "name": "Login - Valid Credentials",
+  "description": "Valid login should succeed and redirect to dashboard",
+  "project_id": 1,
+  "tags": ["smoke","auth"],
+  "priority": "P1",
+  "steps": [
+    { "order": 1, "action": "navigate", "selector": "https://example.com/login" },
+    { "order": 2, "action": "input", "selector": "#email", "value": "user@example.com" },
+    { "order": 3, "action": "input", "selector": "#password", "value": "correct_password" },
+    { "order": 4, "action": "click", "selector": "button[type='submit']" },
+    { "order": 5, "action": "assert", "selector": ".dashboard-welcome", "value": "visible" }
+  ]
+}

--- a/runner/test-data/manifests/playwright-spec-schema.json
+++ b/runner/test-data/manifests/playwright-spec-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Playwright Spec Schema",
+  "type": "object",
+  "required": ["meta", "steps"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "timeout": { "type": "integer" }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "action"],
+        "properties": {
+          "type": { "type": "string" },
+          "action": { "type": "string" },
+          "selector": { "type": "string" },
+          "value": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/runner/test-data/manifests/recorder-output-schema.json
+++ b/runner/test-data/manifests/recorder-output-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Recorder Output Schema",
+  "type": "object",
+  "required": ["id", "name", "steps"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "project_id": { "type": "integer" },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "priority": { "type": "string" },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["order", "action", "selector"],
+        "properties": {
+          "order": { "type": "integer" },
+          "action": { "type": "string" },
+          "selector": { "type": "string" },
+          "value": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/runner/test-data/run-results/canonical/run-login-invalid-001.json
+++ b/runner/test-data/run-results/canonical/run-login-invalid-001.json
@@ -1,0 +1,15 @@
+{
+  "id": "run-login-invalid-001",
+  "test_id": "AC-LOGIN-002",
+  "status": "failed",
+  "environment": "local",
+  "branch": "dev",
+  "commit_hash": "demo-def456",
+  "duration_ms": 1100,
+  "started_at": "2025-11-19T10:05:00.000Z",
+  "finished_at": "2025-11-19T10:05:01.100Z",
+  "artifacts": [
+    { "type": "screenshot", "path": "/artifacts/screenshots/login_invalid_1.png" },
+    { "type": "html-report", "path": "/artifacts/reports/login_invalid_1.html" }
+  ]
+}

--- a/runner/test-data/run-results/canonical/run-login-valid-001.json
+++ b/runner/test-data/run-results/canonical/run-login-valid-001.json
@@ -1,0 +1,14 @@
+{
+  "id": "run-login-valid-001",
+  "test_id": "AC-LOGIN-001",
+  "status": "passed",
+  "environment": "local",
+  "branch": "dev",
+  "commit_hash": "demo-abc123",
+  "duration_ms": 1350,
+  "started_at": "2025-11-19T10:00:00.000Z",
+  "finished_at": "2025-11-19T10:00:01.350Z",
+  "artifacts": [
+    { "type": "screenshot", "path": "/artifacts/screenshots/login_valid_1.png" }
+  ]
+}

--- a/runner/test-data/run-results/examples/sample-run-1.json
+++ b/runner/test-data/run-results/examples/sample-run-1.json
@@ -1,0 +1,12 @@
+{
+  "id": "sample-run-1",
+  "test_id": "SAMPLE-001",
+  "status": "passed",
+  "environment": "local",
+  "branch": "feature/demo",
+  "commit_hash": "demo-000",
+  "duration_ms": 500,
+  "started_at": "2025-11-19T11:00:00.000Z",
+  "finished_at": "2025-11-19T11:00:00.500Z",
+  "artifacts": []
+}

--- a/runner/test-data/run-results/run-login-invalid-001.json
+++ b/runner/test-data/run-results/run-login-invalid-001.json
@@ -1,0 +1,15 @@
+{
+  "id": "run-login-invalid-001",
+  "test_id": "AC-LOGIN-002",
+  "status": "failed",
+  "environment": "local",
+  "branch": "dev",
+  "commit_hash": "demo-def456",
+  "duration_ms": 1100,
+  "started_at": "2025-11-19T10:05:00.000Z",
+  "finished_at": "2025-11-19T10:05:01.100Z",
+  "artifacts": [
+    { "type": "screenshot", "path": "/artifacts/screenshots/login_invalid_1.png" },
+    { "type": "html-report", "path": "/artifacts/reports/login_invalid_1.html" }
+  ]
+}

--- a/runner/test-data/run-results/run-login-valid-001.json
+++ b/runner/test-data/run-results/run-login-valid-001.json
@@ -1,0 +1,14 @@
+{
+  "id": "run-login-valid-001",
+  "test_id": "AC-LOGIN-001",
+  "status": "passed",
+  "environment": "local",
+  "branch": "dev",
+  "commit_hash": "demo-abc123",
+  "duration_ms": 1350,
+  "started_at": "2025-11-19T10:00:00.000Z",
+  "finished_at": "2025-11-19T10:00:01.350Z",
+  "artifacts": [
+    { "type": "screenshot", "path": "/artifacts/screenshots/login_valid_1.png" }
+  ]
+}

--- a/runner/test-data/scripts/generate-regression-bundle.js
+++ b/runner/test-data/scripts/generate-regression-bundle.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+
+const root = path.resolve(process.cwd(), "runner/test-data");
+const canonical = path.join(root, "generated-tests", "canonical");
+const out = path.join(root, "generated-tests", "ci-regression", "regression-bundle.json");
+
+const files = fs.readdirSync(canonical).filter((f) => f.endsWith(".json"));
+
+const bundle = {
+  generated_at: new Date().toISOString(),
+  tests: files.map((f) => path.join("..", "canonical", f))
+};
+
+fs.writeFileSync(out, JSON.stringify(bundle, null, 2));
+console.log("Regression bundle written to:", out);

--- a/runner/test-data/scripts/seed-sample-data.js
+++ b/runner/test-data/scripts/seed-sample-data.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+
+const root = path.resolve(process.cwd(), "runner/test-data");
+const canonicalGT = path.join(root, "generated-tests", "canonical");
+const canonicalRR = path.join(root, "run-results", "canonical");
+
+const targetGT = path.join(root, "generated-tests");
+const targetRR = path.join(root, "run-results");
+
+function copyDir(srcDir, destDir) {
+  if (!fs.existsSync(srcDir)) return;
+  const files = fs.readdirSync(srcDir).filter((f) => f.endsWith(".json"));
+  if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
+  for (const f of files) {
+    const src = path.join(srcDir, f);
+    const dest = path.join(destDir, f);
+    fs.copyFileSync(src, dest);
+    console.log(`Copied ${src} -> ${dest}`);
+  }
+}
+
+function usage() {
+  console.log("Usage: node seed-sample-data.js --target demo|ci");
+  process.exit(0);
+}
+
+const args = process.argv.slice(2);
+if (args.length < 2 || args[0] !== "--target") usage();
+const target = args[1];
+
+if (target === "demo" || target === "ci") {
+  copyDir(canonicalGT, targetGT);
+  copyDir(canonicalRR, targetRR);
+  console.log(`Sample data seeded for target: ${target}`);
+} else {
+  usage();
+}


### PR DESCRIPTION
This PR adds canonical test specifications, run-result artifacts, JSON schema manifests, and helper scripts for seeding and packaging test data.

### Included:
- Canonical generated tests: login_valid, login_invalid_password, checkout_flow
- CI regression manifest and regression bundle script
- Canonical run-results simulating passed and failed runs
- JSON schemas for recorder output and Playwright specs
- Helper scripts:
  - seed-sample-data.js (seed demo/ci data)
  - generate-regression-bundle.js (bundle canonical tests for CI)
- README documenting usage and seeding

### Purpose:
These artifacts provide stable, versioned inputs for QA validation, backend integration tests, recorder/script-generator contract validation, and CI regression runs.

### How to seed locally:
`node runner/test-data/scripts/seed-sample-data.js --target demo`