### PR TITLE
ci: add GitHub Actions workflow for Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,28 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test

--- a/script-generator/src/generate.ts
+++ b/script-generator/src/generate.ts
@@ -1,0 +1,12 @@
+import type { Recording } from './schema';
+
+export const toPlaywrightSpec = (recording: Recording, name = 'Recorded Flow') => {
+  const firstUrl = recording.find(e => e.url)?.url || 'about:blank';
+
+  const steps = recording.map(evt => {
+    if (evt.kind === 'click') return `  await page.click(${JSON.stringify(evt.selector)});`;
+    if (evt.kind === 'input') return `  await page.fill(${JSON.stringify(evt.selector)}, ${JSON.stringify(evt.value)});`;
+    return '';
+  }).join('\n');
+
+  return `import { test, expect } from '@playwright/test';

--- a/script-generator/src/schema.ts
+++ b/script-generator/src/schema.ts
@@ -1,0 +1,4 @@
+export type ClickEvent = { kind: 'click'; selector: string; text?: string; ts?: number; url?: string };
+export type InputEvent = { kind: 'input'; selector: string; value: string; ts?: number; url?: string };
+export type RecordedEvent = ClickEvent | InputEvent;
+export type Recording = RecordedEvent[];


### PR DESCRIPTION
### Overview
Adds GitHub Actions workflow to run Playwright tests automatically on every push and pull request to `dev`.

### Features
- Installs Node.js and dependencies
- Installs Playwright browsers
- Runs `npx playwright test` in CI
- Ensures test results are reproducible and visible in GitHub Actions logs

### Benefits
- Automated test validation for every commit
- Early detection of failures before merging
- Foundation for future artifact uploads (screenshots, reports)
